### PR TITLE
Add Close Hue game entry to dles.json

### DIFF
--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -643,6 +643,12 @@
     "id": 618
   },
   {
+    "name": "Close Hue",
+    "url": "https://closehue.com",
+    "description": "Guess what a color looks like given its name. Pick from 5 color swatches and get scored on how close your guess is. Features daily challenges, unlimited mode, and multiplayer.",
+    "category": "Colors"
+  },
+  {
     "name": "Clue Raider",
     "url": "https://clueraider.com",
     "description": "Find the hidden relic by placing each person based on their clues.",


### PR DESCRIPTION
Adding Close Hue (https://closehue.com) to the Colors category.

Close Hue is a daily color-guessing game where you are given a color name and have to identify what the color looks like. You pick from 5 color swatches and are scored on how close your guess is. It features daily challenges, unlimited mode, and multiplayer.