### PR TITLE
Add Fast Five Quiz (Trivia)

### DIFF
--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -1308,6 +1308,12 @@
     "id": 739
   },
   {
+    "name": "Fast Five Quiz",
+    "url": "https://fastfivequiz.com",
+    "description": "A daily general knowledge quiz with five hand-written questions across five categories. Optional 15-second timer per question, no signup required.",
+    "category": "Trivia"
+  },
+  {
     "name": "Faustdle",
     "url": "https://faustdle.com/",
     "description": "Guess the One Piece character of the day.",


### PR DESCRIPTION
Adds Fast Five Quiz to the directory.

- Name: Fast Five Quiz
- URL: https://fastfivequiz.com
- Category: Trivia
- Description: A daily general knowledge quiz with five hand-written questions across five categories. Optional 15-second timer per question, no signup required.

The quiz refreshes once per day, runs without a login or subscription, and is free to play. Built by a UK indie dev. Happy to tweak the description or category if you'd prefer different wording. Cheers for maintaining this list, it's a great resource.