### PR TITLE
Add Statedoku to Geography

### DIFF
--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -4072,6 +4072,13 @@
     "id": 671
   },
   {
+    "name": "Statedoku",
+    "url": "https://statedoku.com",
+    "description": "Fill a 3×3 grid with US states matching both a row clue and a column clue (e.g. borders Canada × no income tax).",
+    "category": "Geography",
+    "id": 769
+  },
+  {
     "name": "Statele",
     "url": "https://statele.teuteuf.fr",
     "description": "Guess the US State by its outline on the map.",


### PR DESCRIPTION
Adding **Statedoku** to the Geography category — sits right next to Statele.

**Statedoku** — Daily 3×3 grid where each cell must be a US state matching both its row clue and column clue (e.g. "borders Canada" × "no income tax"). 100+ rotating clues, free, no signup, multilingual (EN/FR/ES).

→ https://statedoku.com

Inserted alphabetically (between "Stat Mini Crossword" and "Statele"), id 769. Single-line addition, JSON validated. Thanks for maintaining 700+ games — incredible resource!