### PR TITLE
Add StatesQuest,  TerraeQuest, HistoriaQuest, MetrosQuest and AtomixQuest, HeatmapQuest

### DIFF
--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -158,6 +158,12 @@
     "id": 13
   },
   {
+    "name": "AtomixQuest",
+    "url": "https://atomixquest.com",
+    "description": "Guess the chemical element based on its properties (atomic mass, melting point, electronegativity…) in 5 daily modes.",
+    "category": "Science/Nature"
+  },
+  {
     "name": "Avatardle",
     "url": "https://avatardle.com",
     "description": "A daily guessing game based on the show Avatar: The Last Airbender.",
@@ -1884,6 +1890,12 @@
     "id": 169
   },
   {
+    "name": "HistoriaQuest",
+    "url": "https://historiaquest.com",
+    "description": "Guess where historical figures, inventions and events belong on the timeline — drag and drop to the right date.",
+    "category": "History"
+  },
+  {
     "name": "Historydle",
     "url": "https://historydle.com",
     "description": "Daily games where you guess the historical person or place.",
@@ -2526,6 +2538,12 @@
     "description": "Guess animals to see where they share common ancestors with the mystery animal, eventually guessing the mystery animal.",
     "category": "Science/Nature",
     "id": 226
+  },
+  {
+    "name": "MetrosQuest",
+    "url": "https://metrosquest.com",
+    "description": "Guess the world capital based on its stats (altitude, metro lines, skyscrapers, population…) in 5 daily modes.",
+    "category": "Geography"
   },
   {
     "name": "Minecraftle",

--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -4065,6 +4065,12 @@
     "id": 367
   },
   {
+    "name": "StatesQuest",
+    "url": "https://statesquest.com",
+    "description": "Guess the US state based on its statistics in 4 daily modes.",
+    "category": "Geography"
+  },
+  {
     "name": "StatPad Game",
     "url": "https://www.statpadgame.com",
     "description": "Select MLB players to maximize your score given today's stat category and row requirements.",
@@ -4241,6 +4247,12 @@
     "category": "Video Games",
     "theme": "Terraria",
     "id": 382
+  },
+  {
+    "name": "TerraeQuest",
+    "url": "https://terraequest.com",
+    "description": "Guess the country based on its statistics (population, area, GDP…) in 4 daily modes.",
+    "category": "Geography"
   },
   {
     "name": "Terraformation",

--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -1861,6 +1861,12 @@
     "id": 165
   },
   {
+    "name": "HeatMapQuest",
+    "url": "https://heatmapquest.com",
+    "description": "Guess which statistic is represented on a color-coded 3D globe of the world in 4 daily rounds.",
+    "category": "Geography"
+  },
+  {
     "name": "hello wordl",
     "url": "https://hellowordl.net/?today",
     "description": "Play Wordle puzzles from 4 to 11 letters long.",

--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -2546,12 +2546,6 @@
     "id": 226
   },
   {
-    "name": "MetrosQuest",
-    "url": "https://metrosquest.com",
-    "description": "Guess the world capital based on its stats (altitude, metro lines, skyscrapers, population…) in 5 daily modes.",
-    "category": "Geography"
-  },
-  {
     "name": "Minecraftle",
     "url": "https://minecraftle.zachmanson.com",
     "description": "Guess the crafting recipe from the game Minecraft.",


### PR DESCRIPTION
Hi,

  Adding five dles I built:

   - [Heatmapquest](https://heatmapquest.com/) — A daily geography game where you read the world in color. Every day, a glowing heatmap lights up the globe — figure out which statistic it's hiding.

    - [TerraeQuest](https://terraequest.com) — Guess the country based on its statistics
  (population, area, GDP…) in 4 daily modes.

    - [HistoriaQuest](https://historiaquest.com) — Guess where historical figures,
  inventions and events belong on the timeline — drag and drop to the right date.

    - [StatesQuest](https://statesquest.com) — Guess the US state based on its statistics
  in 4 daily modes.

    - [AtomixQuest](https://atomixquest.com) — Guess the chemical element based on its
  properties (atomic mass, melting point, electronegativity…) in 5 daily modes.

  Thanks  