### PR TITLE
Add 4 daily games: Plot-Hole, TV Addict, Luminary, NORMIE

### DIFF
--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -5127,5 +5127,33 @@
     "description": "Guess the video game from the zoomed-in screenshot.",
     "category": "Video Games",
     "id": 454
+  },
+  {
+    "name": "Plot-Hole",
+    "url": "https://plot-hole.com",
+    "description": "Guess the daily movie from 5 clues that go from cryptic to obvious. Guess early to score higher.",
+    "category": "Movies/TV",
+    "id": 779
+  },
+  {
+    "name": "TV Addict",
+    "url": "https://tv-addict.com",
+    "description": "Guess the daily TV show from 5 clues, vague to obvious. The earlier you guess, the higher your score.",
+    "category": "Movies/TV",
+    "id": 780
+  },
+  {
+    "name": "Luminary",
+    "url": "https://play-luminary.com",
+    "description": "Daily actor trivia: a sentence clue and four photos, three timed rounds each day.",
+    "category": "Movies/TV",
+    "id": 781
+  },
+  {
+    "name": "NORMIE",
+    "url": "https://play-normie.com",
+    "description": "Three daily questions - guess how the crowd voted and find out if you're normal.",
+    "category": "Trivia",
+    "id": 782
   }
 ]


### PR DESCRIPTION
Adding four free, live daily guessing games (no signup, no ads):

- **Plot-Hole** (https://plot-hole.com) — guess the daily movie from 5 clues, vague → obvious, score higher the earlier you guess. *Movies/TV*
- **TV Addict** (https://tv-addict.com) — same format for daily TV shows. *Movies/TV*
- **Luminary** (https://play-luminary.com) — daily actor trivia: a sentence clue + 4 photos, three timed rounds. *Movies/TV*
- **NORMIE** (https://play-normie.com) — three daily opinion/intuition questions; guess how the crowd voted to find out if you're "normal." *Trivia*

Appended to `dles.json` in the existing format (ids 779–782). Happy to re-sort or adjust categories/descriptions if you'd prefer. Thanks for maintaining the list!