### PR TITLE
Add Gazettle (daily word game)

### DIFF
--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -5127,5 +5127,11 @@
     "description": "Guess the video game from the zoomed-in screenshot.",
     "category": "Video Games",
     "id": 454
+  },
+  {
+    "name": "Gazettle",
+    "url": "https://gazettle.app",
+    "description": "Three daily word puzzles in one vintage newspaper: guess by letters (Classic), by meaning (Semantic), or build the word chain (Bridge). Free, no account.",
+    "category": "Words"
   }
 ]


### PR DESCRIPTION
Adds **Gazettle** to the directory: three daily word puzzles in one vintage newspaper (guess by letters, by meaning, or build a word chain). One shared puzzle per day, plays free in the browser, no account.

- URL: https://gazettle.app
- Category: Words

Added per the README (copied an existing entry, omitted the `id` for auto-assignment). JSON validated.