### PR TITLE
Add PunFiction: Box Office Blunders daily game

### DIFF
--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -1,5 +1,11 @@
 [
   {
+    "name": "PunFiction: Box Office Blunders",
+    "url": "https://iwandres.github.io/PunFiction/boxofficeblunders/",
+    "description": "Unravel daily movie parody riddles! Decipher comedic plotlines, follow rhyming word clues, unlock progressive hints, and guess the pun-derful titles of classic films.",
+    "category": "Movies/TV"
+  },
+  {
     "name": "23 Words",
     "url": "https://wordnerd.co/23words",
     "description": "Unscramble 23 words, one by one, without running out of time.",


### PR DESCRIPTION
Hello! I'm submitting my daily wordplay game to be listed on the directory.
### Game Details:
* **Name:** PunFiction: Box Office Blunders
* **Description:** Unravel daily movie parody riddles! Decipher comedic plotlines, follow rhyming word clues, unlock progressive hints, and guess the pun-derful titles of classic films.
* **URL:** https://iwandres.github.io/PunFiction/boxofficeblunders/
* **Category:** Movies/TV
### Verification:
* Free-to-play and ad-supported (no login/subscription required).
* A new, daily-limited puzzle is served every day.
* Added the entry to `src/lib/data/dles.json` without an `id` field (as instructed in the contribution guidelines so that the ID is assigned automatically on merge).
Thanks for maintaining this index!