### PR TITLE
Add Rung — daily game of nerve (dailyrung.com)

### DIFF
--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -5127,5 +5127,12 @@
     "description": "Guess the video game from the zoomed-in screenshot.",
     "category": "Video Games",
     "id": 454
+  },
+  {
+    "name": "Rung",
+    "url": "https://dailyrung.com",
+    "description": "A daily game of nerve: one everyday answer, five clues from cryptic to obvious, worth 5 down to 1 points. Guess early to score big — a wrong guess burns two rungs.",
+    "category": "Words",
+    "theme": "Guess the word"
   }
 ]


### PR DESCRIPTION
Adding **Rung** (https://dailyrung.com) — a daily word game where one everyday answer is revealed through five clues, cryptic to obvious, worth 5→1 points. Guess early for more points; a wrong guess burns two rungs. Meets the dle criteria: daily, same puzzle for everyone worldwide, free, no login. Entry follows the existing format with no id field (auto-assigned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)