### PR TITLE
Add TubeCount

### DIFF
--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -4567,6 +4567,12 @@
     "id": 402
   },
   {
+    "name": "TubeCount",
+    "url": "https://tubecount.com",
+    "description": "Guess how many views a YouTube video got from its thumbnail alone. Title and channel unlock as extra clues, plus a higher/lower streak mode.",
+    "category": "Estimation"
+  },
+  {
     "name": "TuneGuessr",
     "url": "https://www.tuneguessr.net/",
     "description": "Guess the country that the song is from by listening to small parts of it.",


### PR DESCRIPTION
TubeCount (https://tubecount.com) is a daily game where you guess how many views a real YouTube video got, judging only by its thumbnail. Title and channel name unlock as extra clues, and there's also a higher/lower streak mode. It's free, requires no signup, and gets a new puzzle every day at midnight IST.

I'm the maker of TubeCount (launched June 2026) and added it to dles.json following the contributing instructions in the README.