### PR TITLE
Add the five Scorewit daily sports trivia games (Sports)

### DIFF
--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -3744,6 +3744,36 @@
     "id": 656
   },
   {
+    "name": "Scorewit",
+    "url": "https://scorewit.com",
+    "description": "Daily World Cup football trivia \u2014 six questions a day, spoiler-free, every answer linked to its source.",
+    "category": "Sports"
+  },
+  {
+    "name": "Scorewit Baseball",
+    "url": "https://baseball.scorewit.com",
+    "description": "Daily World Series trivia \u2014 six questions a day from game logs back to 1903.",
+    "category": "Sports"
+  },
+  {
+    "name": "Scorewit Cricket",
+    "url": "https://cricket.scorewit.com",
+    "description": "Daily Cricket World Cup trivia, ODI and T20 \u2014 six sourced questions a day.",
+    "category": "Sports"
+  },
+  {
+    "name": "Scorewit F1",
+    "url": "https://f1.scorewit.com",
+    "description": "Daily Formula 1 history trivia \u2014 six questions a day, computed from public race records.",
+    "category": "Sports"
+  },
+  {
+    "name": "Scorewit Gridiron",
+    "url": "https://gridiron.scorewit.com",
+    "description": "Daily NFL history trivia \u2014 six questions a day, every answer cited to play-by-play data.",
+    "category": "Sports"
+  },
+  {
     "name": "Scramble",
     "url": "https://playscramble.vercel.app/?daily=1",
     "description": "Guess as many valid words as possible for each row of a scrambled grid of letters.",


### PR DESCRIPTION
Adds five entries (alphabetized, category Sports):

- **Scorewit** (scorewit.com) — daily World Cup football trivia, six questions a day, spoiler-free.
- **Scorewit Baseball** (baseball.scorewit.com) — daily World Series trivia from game logs back to 1903.
- **Scorewit Cricket** (cricket.scorewit.com) — daily Cricket World Cup trivia, ODI and T20.
- **Scorewit F1** (f1.scorewit.com) — daily Formula 1 history trivia from public race records.
- **Scorewit Gridiron** (gridiron.scorewit.com) — daily NFL history trivia from play-by-play data.

All five share the same daily format: six questions, the same round for everyone, Wordle-style spoiler-free sharing, streaks, and a source link on every answer. Questions are template-generated from official match datasets and independently machine-verified — no AI-written facts. Free, no accounts, no ads.