### PR TITLE
Add the Scorewit family: seven daily sports trivia dles

### DIFF
--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -3744,6 +3744,36 @@
     "id": 656
   },
   {
+    "name": "Scorewit",
+    "url": "https://www.scorewit.com",
+    "description": "Daily World Cup soccer trivia — six sourced questions a day, same round for everyone.",
+    "category": "Sports"
+  },
+  {
+    "name": "Scorewit Baseball",
+    "url": "https://baseball.scorewit.com",
+    "description": "Daily World Series trivia — six sourced questions a day from every Fall Classic since 1903.",
+    "category": "Sports"
+  },
+  {
+    "name": "Scorewit Cricket",
+    "url": "https://cricket.scorewit.com",
+    "description": "Daily Cricket World Cup trivia covering the ODI and T20 World Cups, every answer sourced.",
+    "category": "Sports"
+  },
+  {
+    "name": "Scorewit F1",
+    "url": "https://f1.scorewit.com",
+    "description": "Daily Formula 1 history trivia — every season since 1950, both championships, every answer sourced.",
+    "category": "Sports"
+  },
+  {
+    "name": "Scorewit Gridiron",
+    "url": "https://gridiron.scorewit.com",
+    "description": "Daily NFL history trivia — six sourced questions a day, every season since 1999.",
+    "category": "Sports"
+  },
+  {
     "name": "Scramble",
     "url": "https://playscramble.vercel.app/?daily=1",
     "description": "Guess as many valid words as possible for each row of a scrambled grid of letters.",

--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -3774,6 +3774,18 @@
     "category": "Sports"
   },
   {
+    "name": "Scorewit Super Over",
+    "url": "https://superover.scorewit.com",
+    "description": "Daily IPL history trivia — six sourced questions a day, every season of the tournament.",
+    "category": "Sports"
+  },
+  {
+    "name": "Scorewit Top Flight",
+    "url": "https://topflight.scorewit.com",
+    "description": "Daily English top-flight football trivia — six sourced questions a day from the Premier League era.",
+    "category": "Sports"
+  },
+  {
     "name": "Scramble",
     "url": "https://playscramble.vercel.app/?daily=1",
     "description": "Guess as many valid words as possible for each row of a scrambled grid of letters.",

--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -3751,37 +3751,37 @@
   },
   {
     "name": "Scorewit Baseball",
-    "url": "https://baseball.scorewit.com",
+    "url": "https://www.scorewit.com/baseball",
     "description": "Daily World Series trivia — six sourced questions a day from every Fall Classic since 1903.",
     "category": "Sports"
   },
   {
     "name": "Scorewit Cricket",
-    "url": "https://cricket.scorewit.com",
+    "url": "https://www.scorewit.com/cricket",
     "description": "Daily Cricket World Cup trivia covering the ODI and T20 World Cups, every answer sourced.",
     "category": "Sports"
   },
   {
     "name": "Scorewit F1",
-    "url": "https://f1.scorewit.com",
+    "url": "https://www.scorewit.com/f1",
     "description": "Daily Formula 1 history trivia — every season since 1950, both championships, every answer sourced.",
     "category": "Sports"
   },
   {
     "name": "Scorewit Gridiron",
-    "url": "https://gridiron.scorewit.com",
+    "url": "https://www.scorewit.com/gridiron",
     "description": "Daily NFL history trivia — six sourced questions a day, every season since 1999.",
     "category": "Sports"
   },
   {
     "name": "Scorewit Super Over",
-    "url": "https://superover.scorewit.com",
+    "url": "https://www.scorewit.com/superover",
     "description": "Daily IPL history trivia — six sourced questions a day, every season of the tournament.",
     "category": "Sports"
   },
   {
     "name": "Scorewit Top Flight",
-    "url": "https://topflight.scorewit.com",
+    "url": "https://www.scorewit.com/topflight",
     "description": "Daily English top-flight football trivia — six sourced questions a day from the Premier League era.",
     "category": "Sports"
   },


### PR DESCRIPTION
Seven sibling daily sports-trivia games (Sports category), one per sport, each Wordle-style — six questions a day, the same round for everyone, spoiler-free share, free, no login:

- **Scorewit** — https://www.scorewit.com — daily World Cup soccer trivia
- **Scorewit Cricket** — https://cricket.scorewit.com — daily Cricket World Cup trivia (ODI + T20)
- **Scorewit Baseball** — https://baseball.scorewit.com — daily World Series trivia (every Fall Classic since 1903)
- **Scorewit F1** — https://f1.scorewit.com — daily Formula 1 history trivia (every season since 1950)
- **Scorewit Gridiron** — https://gridiron.scorewit.com — daily NFL history trivia (every season since 1999)
- **Scorewit Super Over** — https://superover.scorewit.com — daily IPL cricket trivia (every season of the tournament)
- **Scorewit Top Flight** — https://topflight.scorewit.com — daily English top-flight football trivia (Premier League era)

Editorial note: questions are template-generated from official match datasets (nflverse, Cricsheet, F1DB, Retrosheet, openfootball) and independently machine-verified — no AI-written facts. Entries follow the README convention (copied an existing entry's shape, id omitted). Thanks for maintaining the list!