### PR TITLE
Add Threezy

### DIFF
--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -4483,7 +4483,7 @@
   },
   {
     "name": "Threezy",
-    "url": "https://threezy.pages.dev/?utm_source=thedles",
+    "url": "https://threezy.net/?utm_source=thedles",
     "description": "Spot trios of cards where shape, color, and fill are each all the same or all different. New shared puzzle daily.",
     "category": "Shapes/Patterns"
   },

--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -4482,6 +4482,12 @@
     "id": 390
   },
   {
+    "name": "Threezy",
+    "url": "https://threezy.pages.dev/?utm_source=thedles",
+    "description": "Spot trios of cards where shape, color, and fill are each all the same or all different. New shared puzzle daily.",
+    "category": "Shapes/Patterns"
+  },
+  {
     "name": "Thrice",
     "url": "https://thrice.geekswhodrink.com",
     "description": "Answer today's 5 trivia questions, each from a different category.",


### PR DESCRIPTION
Adds **Threezy** to the list.

Threezy is a daily card puzzle: find trios among nine cards where shape, color, and fill are each all the same or all different. Everyone plays the same seeded daily board, and it's free with no login, no subscription, and no ads, so it fits the dle criteria.

- Play: https://threezy.pages.dev/
- Daily, same board for everyone, free, no account.

Inserted alphabetically in the T section; omitted the `id` field per the README's "remove the id" note so it can be auto-assigned. Thanks for maintaining the list!