### PR TITLE
Played Dles can reset on their own timezone

### DIFF
--- a/src/lib/components/Dles/MarkedDlesModal.svelte
+++ b/src/lib/components/Dles/MarkedDlesModal.svelte
@@ -34,7 +34,7 @@
     const count = previousPlayedDles.length
 
     if (isLocalStorageAvailable()) {
-      localStorage.playedDlesLastReset = new Date().toDateString()
+      localStorage.playedDlesLastReset = new Date().toISOString()
     }
 
     if (count > 0) {
@@ -67,7 +67,7 @@
     if (isLocalStorageAvailable()) {
       localStorage.autoResetPlayed = $autoResetPlayed.toString()
       if ($autoResetPlayed) {
-        localStorage.playedDlesLastReset = new Date().toDateString()
+        localStorage.playedDlesLastReset = new Date().toISOString()
       }
     }
   }
@@ -93,7 +93,7 @@
           class:active={$autoResetPlayed}
           on:click={toggleAutoResetPlayed}
         >
-          <span class="toggle-label">Auto-reset at midnight</span>
+          <span class="toggle-label">Auto-reset daily</span>
           <span class="toggle-status">{$autoResetPlayed ? "ON" : "OFF"}</span>
         </button>
       </div>

--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -1390,6 +1390,7 @@
     "url": "https://inkwellgames.com/games/fields",
     "description": "Fill the grid with colorful fields that never connect.",
     "category": "Math/Logic",
+    "resetTime": "client",
     "id": 467
   },
   {
@@ -2268,6 +2269,7 @@
     "url": "https://inkwellgames.com/games/lazy-river",
     "description": "Draw a single continuous loop that flows through every cell.",
     "category": "Shapes/Patterns",
+    "resetTime": "client",
     "id": 773
   },
   {
@@ -2388,6 +2390,7 @@
     "url": "https://www.linkedin.com/games/crossclimb",
     "description": "Guess the words that fit the clues, then rearrange to create a word ladder. Does not require a LinkedIn account.",
     "category": "Words",
+    "resetTime": "America/Los_Angeles",
     "id": 205
   },
   {
@@ -2395,6 +2398,7 @@
     "url": "https://www.linkedin.com/games/mini-sudoku/",
     "description": "A daily 6x6 Sudoku puzzle. Does not require a LinkedIn account.",
     "category": "Math/Logic",
+    "resetTime": "America/Los_Angeles",
     "id": 565
   },
   {
@@ -2402,6 +2406,7 @@
     "url": "https://www.linkedin.com/games/patches/",
     "description": "Partition the grid so that each number lies within a rectangle of that area. Does not require a LinkedIn account.",
     "category": "Shapes/Patterns",
+    "resetTime": "America/Los_Angeles",
     "id": 783
   },
   {
@@ -2409,6 +2414,7 @@
     "url": "https://www.linkedin.com/games/pinpoint",
     "description": "Guess today's category given as few clues as possible. Does not require a LinkedIn account.",
     "category": "Words",
+    "resetTime": "America/Los_Angeles",
     "id": 206
   },
   {
@@ -2416,6 +2422,7 @@
     "url": "https://www.linkedin.com/games/queens",
     "description": "Place queens on the board such that exactly one is in each row, column, and color region. Does not require a LinkedIn account.",
     "category": "Math/Logic",
+    "resetTime": "America/Los_Angeles",
     "id": 207
   },
   {
@@ -2423,6 +2430,7 @@
     "url": "https://www.linkedin.com/games/tango",
     "description": "Fill in the grid properly with suns and moons. Does not require a LinkedIn account.",
     "category": "Math/Logic",
+    "resetTime": "America/Los_Angeles",
     "id": 208
   },
   {
@@ -2430,6 +2438,7 @@
     "url": "https://www.linkedin.com/games/wend/",
     "description": "Find the hidden words that partition the grid of letters. Does not require a LinkedIn account.",
     "category": "Words",
+    "resetTime": "America/Los_Angeles",
     "id": 784
   },
   {
@@ -2437,6 +2446,7 @@
     "url": "https://www.linkedin.com/games/zip",
     "description": "Connect the numbered dots in the grid in order, starting at 1. Does not require a LinkedIn account.",
     "category": "Shapes/Patterns",
+    "resetTime": "America/Los_Angeles",
     "id": 209
   },
   {
@@ -4208,6 +4218,7 @@
     "url": "https://inkwellgames.com/games/stars",
     "description": "Distribute stars strategically across the grid without letting them touch.",
     "category": "Math/Logic",
+    "resetTime": "client",
     "id": 501
   },
   {

--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -703,6 +703,7 @@
     "url": "https://cluesbysam.com",
     "description": "Use the clues to figure out which characters are innocent and which are criminals.",
     "category": "Math/Logic",
+    "resetTime": "America/New_York",
     "id": 55
   },
   {
@@ -4545,6 +4546,7 @@
     "url": "https://www.tictacword.com",
     "description": "Make three in a row by guessing words that fit today's theme, like Tic-Tac-Toe meets Wordle.",
     "category": "Words",
+    "resetTime": "client",
     "id": 787
   },
   {

--- a/src/lib/js/playedReset.js
+++ b/src/lib/js/playedReset.js
@@ -1,0 +1,49 @@
+// Helpers for the "mark as played today" auto-reset.
+//
+// Each dle carries an optional `resetTime`:
+//   - absent or "client" -> resets at 00:00 in the user's local timezone
+//   - an IANA timezone string (e.g. "America/Los_Angeles") -> resets at 00:00 in that zone
+//
+// The last reset check is persisted as a single ISO datetime in
+// localStorage.playedDlesLastReset. On load we drop a played dle only when a
+// midnight in its own zone fell between that instant and now.
+
+export function getResetTime(dle) {
+  return dle?.resetTime || "client"
+}
+
+// The wall-clock day (YYYY-MM-DD) that `date` falls on in the given zone.
+// "client" uses the user's local timezone.
+export function dayInZone(date, resetTime) {
+  const options = resetTime === "client" ? {} : { timeZone: resetTime }
+  return date.toLocaleDateString("en-CA", options)
+}
+
+// Parses both legacy date-only strings ("Wed Jul 22 2026") and ISO datetimes.
+// Returns null when absent or unparseable.
+export function parseResetDate(raw) {
+  if (!raw) {
+    return null
+  }
+  const date = new Date(raw)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+// Returns the ids that should stay marked. A dle survives only if we have a
+// baseline (`lastReset`) and no midnight in its zone has passed since then.
+export function computePlayedReset(playedIds, dles, lastReset, now = new Date()) {
+  if (!lastReset) {
+    return []
+  }
+
+  const byId = new Map(dles.map((dle) => [dle.id, dle]))
+  const currentDayByZone = {}
+
+  return playedIds.filter((id) => {
+    const zone = getResetTime(byId.get(id))
+    if (!(zone in currentDayByZone)) {
+      currentDayByZone[zone] = dayInZone(now, zone)
+    }
+    return dayInZone(lastReset, zone) === currentDayByZone[zone]
+  })
+}

--- a/src/lib/js/playedReset.js
+++ b/src/lib/js/playedReset.js
@@ -1,26 +1,13 @@
-// Helpers for the "mark as played today" auto-reset.
-//
-// Each dle carries an optional `resetTime`:
-//   - absent or "client" -> resets at 00:00 in the user's local timezone
-//   - an IANA timezone string (e.g. "America/Los_Angeles") -> resets at 00:00 in that zone
-//
-// The last reset check is persisted as a single ISO datetime in
-// localStorage.playedDlesLastReset. On load we drop a played dle only when a
-// midnight in its own zone fell between that instant and now.
-
-export function getResetTime(dle) {
-  return dle?.resetTime || "client"
-}
-
-// The wall-clock day (YYYY-MM-DD) that `date` falls on in the given zone.
-// "client" uses the user's local timezone.
 export function dayInZone(date, resetTime) {
-  const options = resetTime === "client" ? {} : { timeZone: resetTime }
-  return date.toLocaleDateString("en-CA", options)
+  try {
+    // if the resetTime is undefined, the default behaviour is to use the client's timezone
+    const options = !!resetTime && resetTime !== "client" ? { timeZone: resetTime } : {}
+    return date.toLocaleDateString("en-CA", options)
+  } catch {
+    return date.toLocaleDateString("en-CA")
+  }
 }
 
-// Parses both legacy date-only strings ("Wed Jul 22 2026") and ISO datetimes.
-// Returns null when absent or unparseable.
 export function parseResetDate(raw) {
   if (!raw) {
     return null
@@ -37,13 +24,13 @@ export function computePlayedReset(playedIds, dles, lastReset, now = new Date())
   }
 
   const byId = new Map(dles.map((dle) => [dle.id, dle]))
-  const currentDayByZone = {}
+  const survivesByZone = {} // cache to avoid Intl.DateTimeFormat computation
 
   return playedIds.filter((id) => {
-    const zone = getResetTime(byId.get(id))
-    if (!(zone in currentDayByZone)) {
-      currentDayByZone[zone] = dayInZone(now, zone)
+    const zone = byId.get(id)?.resetTime
+    if (!(zone in survivesByZone)) {
+      survivesByZone[zone] = dayInZone(lastReset, zone) === dayInZone(now, zone)
     }
-    return dayInZone(lastReset, zone) === currentDayByZone[zone]
+    return survivesByZone[zone]
   })
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -40,6 +40,7 @@
     getCurrentDlesOfTheWeek,
     isLocalStorageAvailable,
   } from "$lib/js/utilities"
+  import { computePlayedReset, parseResetDate } from "$lib/js/playedReset"
   import {
     migrateFavoritesToIds,
     needsFavoritesMigration,
@@ -113,15 +114,17 @@
       $autoResetPlayed = localStorage.autoResetPlayed !== "false"
 
       if ($autoResetPlayed) {
-        const today = new Date().toDateString()
-        const lastResetDate = localStorage.playedDlesLastReset
+        // Unmark only the dles whose own reset boundary has passed since the
+        // last check (per-dle resetTime; defaults to the user's local midnight).
+        const now = new Date()
+        const lastReset = parseResetDate(localStorage.playedDlesLastReset)
+        const remaining = computePlayedReset($playedDleIds, $dles, lastReset, now)
 
-        if (lastResetDate !== today) {
-          // Reset played dles at midnight
-          $playedDleIds = []
-          localStorage.playedDles = JSON.stringify([])
-          localStorage.playedDlesLastReset = today
+        if (remaining.length !== $playedDleIds.length) {
+          $playedDleIds = remaining
+          localStorage.playedDles = JSON.stringify(remaining)
         }
+        localStorage.playedDlesLastReset = now.toISOString()
       }
     }
   })


### PR DESCRIPTION
In this proposal, I change the behaviour of "reset played dles at midnight" proposed at #13 . The problem is, different dles have their own reset time: some are reset on their own specific timezone, some reset based on the client's timezone. So I propose a change:

* Every dles will have "resetTime" to indicate whether the dles should reset on what timezone. By default, the value is "client", which means it will follow the client device's timezone. This is backward compatible, following the current behaviour.
* Instead of storing the date of the last reset, we store the time too (in ISO format). This way, we can reset each dles individually.
* Add some of known reset time.

I can help to check the reset time of the dles as many as I can, but I want to get opinions before committing more time on this idea.

Additionally, I also have an idea to show some timer / small alert if some of the favourited dles is approaching the deadline but not marked yet, so it will help to keep daily streak? But this might be too much UI disruption for not much benefit, considering most of dles doesn't have concept of daily streak anyway.