### PR TITLE
Add Read the Tape

### DIFF
--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -3603,6 +3603,12 @@
     "id": 521
   },
   {
+    "name": "Read the Tape",
+    "url": "https://readthetape.cc",
+    "description": "Guess whether 5 unlabelled S&P 500 charts go up or down over the next 5 trading days.",
+    "category": "Estimation"
+  },
+  {
     "name": "Real Bird Fake Bird",
     "url": "https://realbirdfakebird.com",
     "description": "Guess if each of the 7 prompts are real or fake (made up or don't belong).",


### PR DESCRIPTION
Adds Read the Tape (https://readthetape.cc), a daily stock chart game. 5 unlabelled historical S&P 500 charts a day, same set for everyone, call up or down for the next 5 trading days. Free, no login. Filed under Estimation, happy to move it if another category fits better.

Followed the README: copied an existing entry, no id field.