### PR TITLE
Add Spectrle to the dles list

### DIFF
--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -4020,6 +4020,12 @@
     "id": 349
   },
   {
+    "name": "Spectrle",
+    "url": "https://spectrle.games",
+    "description": "Guess the movie from its color spectrum - the whole film compressed into one radial gradient. Each wrong guess adds a clue and redraws it from fewer, wider frames. Includes a daily video game puzzle and The Grid, a nine-spectrum matching mode.",
+    "category": "Movies/TV"
+  },
+  {
     "name": "Spell Bee",
     "url": "https://www.spell-bee.com/game-daily.html",
     "description": "Create words using the given 7 letters. Each word must contain the center letter.",


### PR DESCRIPTION
Adding **[Spectrle](https://spectrle.games)**  a free daily puzzle where you guess a movie from its color spectrum.

The whole film gets sampled, compressed, and rendered as a radial gradient a kind of color fingerprint of the entire runtime. You get five guesses, and each miss adds a text clue and redraws the spectrum from fewer, wider frames, so it starts as pure abstract color and gradually resolves into recognizable stills.

Free, no login, no subscription, new puzzle daily, and there's a full archive of past days.

A couple of notes on how I filed it:

- **Category: Movies/TV**, alongside Framed and CineNerdle. There's also a daily *video game* puzzle (same mechanic, sampled from a full playthrough) that would fit Video Games, but the list looks like it keeps one entry per game, so I mentioned it in the description rather than adding a second entry. Happy to split it if you'd prefer.
- **No `id` field**, per the contributing instructions.

Thanks for maintaining this list!

