### PR TITLE
Add ALLEGEDLY

### DIFF
--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -94,6 +94,12 @@
     "id": 567
   },
   {
+    "name": "ALLEGEDLY",
+    "url": "https://playallegedly.com",
+    "description": "Guess the celebrity in the redacted tabloid story. Three strikes, and every miss unlocks a clue.",
+    "category": "Trivia"
+  },
+  {
     "name": "Alphalock",
     "url": "https://alphalockgame.net",
     "description": "Word puzzle game inspired by Wordle and Mastermind.",


### PR DESCRIPTION
Adding **ALLEGEDLY** — https://playallegedly.com

A daily celebrity-guessing game in the form of a redacted tabloid blind item. Each day you get one real, documented story from the public record with the subject's name blacked out; you have three strikes to name them, and every miss unlocks a clue.

- Free, browser-based, no account, no install, no paywall
- New edition daily at local midnight (timezone-safe — the answer is never published while anyone is still playing)
- Bank of 55 hand-written cases; about half are the "Good News Desk" (celebrities documented doing something kind rather than scandalous)
- Also has a harder Night Edition, five themed desks, and scored five-case runs

Categorised as **Trivia** — it spans film, music, sports and TV rather than sitting in any one of them.

Entry inserted alphabetically, `id` omitted per the README. Diff is the six added lines only.

Thanks for maintaining this list — it's the best-kept one in the genre.