### PR TITLE
Add Impress, a daily word game

### DIFF
--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -2068,6 +2068,12 @@
     "id": 180
   },
   {
+    "name": "Impress",
+    "url": "https://impress.ink",
+    "description": "Spell words to reveal a hidden headline that uses every letter on the board, but each letter has only so much ink.",
+    "category": "Words"
+  },
+  {
     "name": "Isaacle",
     "url": "https://isaacle.net",
     "description": "Guess the items from the game The Binding of Isaac in these daily quizzes.",


### PR DESCRIPTION
Adds **[Impress](https://impress.ink)** to `dles.json`.

You compose words from a case of letters; every word both reveals tiles of a hidden headline — one word using every letter on the board — and spends ink from the letters you use. Spelling the headline ends the round, so the game is about how much you score before you finish rather than whether you finish.

- Free, browser-only. No account, no download, no paywall.
- New board every day, same for everyone. Every past day stays playable from the menu, so the archive doesn't 404.
- Works offline once loaded, and installs to a home screen if you want it to.

Added alphabetically between *Immaculate Grid: Women's Basketball* and *Isaacle*, category `Words`, with no `id` field so one gets assigned. I left `theme` off since most Words entries don't carry one.

Happy to reword the description or move the category if you'd rather — and thanks for maintaining the list.