### PR TITLE
Add Yubori

### DIFF
--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -5223,6 +5223,12 @@
     "id": 738
   },
   {
+    "name": "Yubori",
+    "url": "https://yubori.com",
+    "description": "Guess the anime of the day across five modes: emoji, synopsis, stats, versus, and obscure Deep Cuts.",
+    "category": "Movies/TV"
+  },
+  {
     "name": "Zaggle",
     "url": "https://playzaggle.com",
     "description": "Trace words in the grid based on the given clues.",


### PR DESCRIPTION
Adds Yubori, a daily anime guessing game with five modes in one site (emoji, synopsis, stats, versus, and a harder "Deep Cuts" mode). Free, no login, same puzzle worldwide, resets at midnight UTC. Built on the AniList API — no generative-AI content. Category set to Movies/TV to match Jojodle; id omitted so it is assigned automatically per the README.