### PR TITLE
Add Redactle Rush

### DIFF
--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -3617,6 +3617,12 @@
     "id": 316
   },
   {
+    "name": "Redactle Rush",
+    "url": "https://redactlerush.com",
+    "description": "Guess ten redacted Wikipedia subjects, one guess each, with a single hint.",
+    "category": "Trivia"
+  },
+  {
     "name": "Redividers",
     "url": "https://redividers.netlify.app",
     "description": "Find the word that fits the first blank, then split it to fill in the remaining blank(s).",


### PR DESCRIPTION
Adding Redactle Rush, a faster version of Redactle (already on the list under Trivia). Ten redacted Wikipedia subjects, one guess each, one hint if you get stuck. Takes a couple of minutes instead of half an hour.

Same category as Redactle.

Thanks for maintaining the list.
