### PR TITLE
Add Sleuth the Truth

### DIFF
--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -3933,6 +3933,12 @@
     "id": 679
   },
   {
+    "name": "Sleuth the Truth",
+    "url": "https://sleuththetruth.com",
+    "description": "Ask yes/no questions to deduce the hidden Wikipedia article from a grid of suspects in as few moves as possible.",
+    "category": "Trivia"
+  },
+  {
     "name": "Smashdle",
     "url": "https://smashdle.net",
     "description": "A bunch of daily games where you guess the character from Super Smash Bros.",


### PR DESCRIPTION
Adding Sleuth the Truth, a deduction puzzle I built. You get a grid of Wikipedia articles as suspects and ask yes/no questions to narrow down which one is the answer. Fewer questions is a better score.

I put it in Trivia to sit near the other Wikipedia games, but happy to move it if you'd rather it went somewhere else.

Thanks for the work you put into this list.
