### PR TITLE
Add Wild Guessr

### DIFF
--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -4920,6 +4920,12 @@
     "id": 775
   },
   {
+    "name": "Wild Guessr",
+    "url": "https://wildguessr.com",
+    "description": "Guess where each wildlife photo was taken on a world map, 5 rounds every day.",
+    "category": "Science/Nature"
+  },
+  {
     "name": "Wildlife Sudoku",
     "url": "https://flagdoku.com/wildlife.html",
     "description": "Guess 9 animals that properly fill in the grid.",


### PR DESCRIPTION
Adding Wild Guessr. Every day you get 5 wildlife photos from iNaturalist (all CC licensed) and guess on a map where each one was taken.

I filed it under Science/Nature because the photos are the whole point, though Geography would work too. Your call.

Thanks for running this, it's a great resource.
