### PR TITLE
Add LogPose

### DIFF
--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -2496,6 +2496,12 @@
     "id": 215
   },
   {
+    "name": "LogPose",
+    "url": "https://onepiecedle.fr",
+    "description": "Guess the daily One Piece character in 7 different modes, or duel a friend in a 1v1 Versus match.",
+    "category": "Movies/TV"
+  },
+  {
     "name": "LoLdle",
     "url": "https://loldle.net",
     "description": "A bunch of daily games where you guess the champion from League of Legends.",


### PR DESCRIPTION
Adding **LogPose** (https://onepiecedle.fr), a daily One Piece guessing game.

It sits alongside the two One Piece entries already listed (Onepiecedle, Faustdle) but differs on two points: it runs **7 daily modes** rather than one — attributes grid, wanted poster, silhouette, Devil Fruit, emoji, opening theme and volume cover — and it has a **1v1 Versus mode** where two players race on the same mystery character over Bo1/Bo3/Bo5. It is free, needs no sign-up, and is available in French and English.

Entry inserted in alphabetical order between `Logiquiz` and `LoLdle`. The `id` field is omitted as the README instructs. `dles.json` still parses and the alphabetical ordering is preserved (741 -> 742 entries).