### PR TITLE
Add Long Story Short

### DIFF
--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -2504,6 +2504,12 @@
     "id": 216
   },
   {
+    "name": "Long Story Short",
+    "url": "https://sheets.works/long-story-short",
+    "description": "Cut a sentence to five of its own words. Wordle scoring, one a day.",
+    "category": "Words"
+  },
+  {
     "name": "Loopy",
     "url": "https://loopy.wtf",
     "description": "Make a loop based on the numbers in the grid.",


### PR DESCRIPTION
Daily word game. Free, no account, browser. Matches the listing rules.

- Name: Long Story Short
- URL: https://sheets.works/long-story-short
- Category: Words
- Description: Cut a sentence to five of its own words. Wordle scoring, one a day.

No `id` field, as requested in the README.