### PR TITLE
Add Criboku to Card/Board Games

### DIFF
--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -876,6 +876,12 @@
     "id": 730
   },
   {
+    "name": "Criboku",
+    "url": "https://criboku.com",
+    "description": "Fill a 4x4 grid of cards so every row, column and corner square scores as a cribbage hand.",
+    "category": "Card/Board Games"
+  },
+  {
     "name": "Cropple",
     "url": "https://cropple.app",
     "description": "Guess the thing based on a cropped image, you can zoom out or ask for letters.",


### PR DESCRIPTION
Adds Criboku — https://criboku.com/ — a daily cribbage-based logic puzzle.
Sixteen cards in a 4x4 grid form twelve overlapping cribbage hands, and you
deduce the missing cards from the printed scores.

Free, browser-based, no account, new puzzle every day.

Inserted alphabetically between Crayondle and Cropple, with no id field per
the README. I submitted via the Tally form on 29 July but it doesn't appear
in suggested_dles.json, so I suspect it didn't come through — happy to close
this if it's already queued somewhere.