### PR TITLE
Add SoulsDoku

### DIFF
--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -4099,9 +4099,9 @@
   {
     "name": "SoulsDoku",
     "url": "https://www.soulsdoku.com",
-    "description": "Daily FromSoftware boss guessing games: a 3x3 grid, classic clues, silhouettes, lore and arenas across Dark Souls, Elden Ring, Bloodborne and Sekiro.",
+    "description": "Daily FromSoftware boss guessing games: a 3x3 grid, classic clues, silhouettes, lore and arenas across Demon's Souls, Dark Souls, Bloodborne, Sekiro and Elden Ring.",
     "category": "Video Games",
-    "theme": "Soulsborne"
+    "theme": "Souls"
   },
   {
     "name": "SpaceWord",

--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -4097,6 +4097,13 @@
     "id": 348
   },
   {
+    "name": "SoulsDoku",
+    "url": "https://www.soulsdoku.com",
+    "description": "Daily FromSoftware boss guessing games: a 3x3 grid, classic clues, silhouettes, lore and arenas across Dark Souls, Elden Ring, Bloodborne and Sekiro.",
+    "category": "Video Games",
+    "theme": "Soulsborne"
+  },
+  {
     "name": "SpaceWord",
     "url": "https://spaceword.org",
     "description": "Create crosswords using all letters, using as little space as possible.",


### PR DESCRIPTION
Adds **SoulsDoku** (https://www.soulsdoku.com) — daily FromSoftware boss guessing games: a 3×3 category grid, classic-style clues, silhouettes, lore and arena modes across Demon's Souls, Dark Souls, Bloodborne, Sekiro and Elden Ring.

Free, browser-based, no login, new puzzles daily at midnight UTC (same for everyone), full archive of past days.

Entry follows the existing format (alphabetical position, "Souls" theme, no id per the README). I'm the developer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTdG8EUMXv2w7XjXdR7RM5