### PR TITLE
Add Common Ground

### DIFF
--- a/data/dles/new-common-ground.yaml
+++ b/data/dles/new-common-ground.yaml
@@ -1,0 +1,5 @@
+name: Common Ground
+url: https://commonground.games
+description: Sort sixteen words into four quiet kinships. International by design — no US-only categories.
+category: Words
+status: active


### PR DESCRIPTION
Adds Common Ground (https://commonground.games) to the Words category.

Sort sixteen words into four quiet kinships. Free, browser-based, one puzzle a day, no login, and there is a public archive. International by design, so no US-only categories.

I added it as a `data/dles/new-common-ground.yaml` stub via `new_dle.py` rather than editing `src/lib/data/dles.json`, since that file is generated now. `python generate.py --check` on this branch reports `Registered id 831: new-common-ground.yaml would be -> 0831-common-ground.yaml` and dles.json going to 757 entries. The Contributing section of the README still describes the older json edit, so say the word if you would rather have it that way.

Disclosure: I work on the game.
