### PR TITLE
Add GTA6dle

### DIFF
--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -1805,6 +1805,15 @@
     "id": 681
   },
   {
+    "name": "GTA6dle",
+    "url": "https://www.gta6dle.com",
+    "description": "Four daily Grand Theft Auto VI games: guess the character from their traits, pin the location on the Leonida map, name who said the line, or identify the vehicle.",
+    "category": "Video Games",
+    "themes": [
+      "Grand Theft Auto"
+    ]
+  },
+  {
     "name": "Guess My Word",
     "url": "https://hryanjones.com/guess-my-word",
     "description": "Make guesses and see if they are alphabetically before or after the secret word.",


### PR DESCRIPTION
Adds [GTA6dle](https://www.gta6dle.com) to `dles.json`.

A daily Grand Theft Auto VI guessing game with four modes, each with a new puzzle at 00:00 UTC:

- **Classic** — guess the character from their traits
- **Map** — pin the day's location on the Leonida map
- **Quote** — name who said the line
- **Vehicle** — identify the car from its spec sheet

Free, and playable without an account. Filed under **Video Games** with the theme `Grand Theft Auto`, inserted in alphabetical order and with `id` omitted so it gets assigned automatically, per the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CAwxHCLi1mi4BWBkyWgRb1