### PR TITLE
Add Futbolle (Sports)

### DIFF
--- a/src/lib/data/dles.json
+++ b/src/lib/data/dles.json
@@ -1790,6 +1790,15 @@
     "id": 471
   },
   {
+    "name": "Futbolle",
+    "url": "https://futbolle.com",
+    "description": "Daily soccer puzzles with live multiplayer rooms: guess the player who played for both clubs against friends or a Twitch chat.",
+    "category": "Sports",
+    "themes": [
+      "Soccer"
+    ]
+  },
+  {
     "name": "Futdoku",
     "url": "https://flagdoku.com/futdoku.html",
     "description": "Guess 9 soccer players that fill the FUTDOKU grid.",


### PR DESCRIPTION
Futbolle is a free daily football site. Alongside the solo dailies it has something I could not find anywhere else in the list: **real-time multiplayer rooms** — you share a link and play the club-crossover guessing game against friends or a Twitch chat, with answers validated on the server. Searching the current dles.json, no entry mentions multiplayer or head-to-head play.

- Free, no login, no subscription. Every puzzle is the same for everyone that day and resets at the player's local midnight.
- The daily guessing games have a guess limit and can be lost; a player you have already used is filtered out of the search box, so the same name cannot be entered twice. Two of the games are scored differently by design: Transfer Fee is a five-round score and Tic-Tac-Toe is played against an opponent.
- Every game page carries written rules below the board, so they can be read mid-game.
- The data is real and verified rather than generated: squads are re-synced each season from Wikidata and Wikipedia, and all 9,204 player photos are real photographs cut out by scripts whose output is checked by eye. There is no AI-generated art and no invented statistic — where a source has no number for a row, the game shows none instead of a plausible-looking one.
- English, Turkish and Spanish, each on its own crawlable URL.

Context: I opened issue #88 with this suggestion on 11 August. Opening a PR in case the issue queue is long — happy to change the description or category.
